### PR TITLE
make sure FormsyAutoComplete opens its menu when valid search string typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This library is a wrapper for [Material-UI](http://material-ui.com/) form components to allow them to be used
 with [formsy-react](https://github.com/christianalfoni/formsy-react), a form validation component for React forms.
 
+I forked it in order to fix a bug in FormsyAutoComplete that prevents the menu from opening when a valid search string is typed.
+
 ## Installation
 
 To and install formsy-material-ui and add it to your `package.json`, run:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 This library is a wrapper for [Material-UI](http://material-ui.com/) form components to allow them to be used
 with [formsy-react](https://github.com/christianalfoni/formsy-react), a form validation component for React forms.
 
-I forked it in order to fix a bug in FormsyAutoComplete that prevents the menu from opening when a valid search string is typed.
-
 ## Installation
 
 To and install formsy-material-ui and add it to your `package.json`, run:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "formsy-react": "^0.19.0",
-    "material-ui": "^0.17.0",
+    "material-ui": "^0.18.1",
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui-fork-ck",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui-fork-ck",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "formsy-material-ui",
+  "name": "formsy-material-ui-fork-ck",
   "version": "0.6.0",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mbrookes/formsy-material-ui.git"
+    "url": "git+https://github.com/charleskoehl/formsy-material-ui.git"
   },
   "files": [
     "lib",
@@ -76,14 +76,14 @@
     "jsx",
     "react-component"
   ],
-  "author": {
-    "name": "Matt Brookes",
-    "email": "npm@nospam.33m.co",
-    "url": "https://github.com/mbrookes"
-  },
+  "author": "Matt Brookes <npm@nospam.33m.co> (https://github.com/mbrookes)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mbrookes/formsy-material-ui/issues"
   },
-  "homepage": "https://github.com/mbrookes/formsy-material-ui#readme"
+  "homepage": "https://github.com/mbrookes/formsy-material-ui#readme",
+  "directories": {
+    "example": "examples",
+    "test": "test"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui-fork-ck",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui-fork-ck",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -76,14 +76,14 @@
     "jsx",
     "react-component"
   ],
-  "author": "Matt Brookes <npm@nospam.33m.co> (https://github.com/mbrookes)",
+  "author": {
+    "name": "Matt Brookes",
+    "email": "npm@nospam.33m.co",
+    "url": "https://github.com/mbrookes"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/mbrookes/formsy-material-ui/issues"
   },
-  "homepage": "https://github.com/mbrookes/formsy-material-ui#readme",
-  "directories": {
-    "example": "examples",
-    "test": "test"
-  }
+  "homepage": "https://github.com/mbrookes/formsy-material-ui#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui-fork-ck",
-  "version": "0.7.0",
+  "version": "0.1.0",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsy-material-ui-fork-ck",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A formsy-react compatibility wrapper for Material-UI form components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/FormsyAutoComplete.jsx
+++ b/src/FormsyAutoComplete.jsx
@@ -37,6 +37,8 @@ const FormsyAutoComplete = React.createClass({
     this.setState({
       value: event.currentTarget.value,
     });
+    // The next line makes sure AutoComplete opens its menu (because its onChange handler is overwritten):
+    this.autoCompleteComponent.handleChange(event);
     if (this.props.onChange) this.props.onChange(event);
   },
 

--- a/src/FormsyAutoComplete.jsx
+++ b/src/FormsyAutoComplete.jsx
@@ -54,6 +54,11 @@ const FormsyAutoComplete = React.createClass({
 
   setMuiComponentAndMaybeFocus: setMuiComponentAndMaybeFocus,
 
+  setAutoCompleteRef: function(component) {
+    this.autoCompleteComponent = component;
+    return this.setMuiComponentAndMaybeFocus;
+  },
+
   render() {
     const {
       defaultValue, // eslint-disable-line no-unused-vars
@@ -70,7 +75,7 @@ const FormsyAutoComplete = React.createClass({
         onUpdateInput={this.handleUpdateInput}
         onFocus={onFocus}
         onKeyDown={this.handleKeyDown}
-        ref={this.setMuiComponentAndMaybeFocus}
+        ref={this.setAutoCompleteRef}
         value={this.state.value}
       />
     );


### PR DESCRIPTION
FormsyAutoComplete no longer opens its menu of choices when you type a valid search string because it overwrites the onChange method of the wrapped AutoComplete.

This change uses a ref to the wrapped AutoComplete to call its handleChange method.